### PR TITLE
Update README to reflect that Rails 5.2 and 6.0 are now supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ActiveJob jobs.
 Supported Versions
 ------------------
 
-Rails 4.2, 5.0, and 5.1 are supported, Ruby 2.1+. Other Ruby runtimes (e.g. JRuby,
+Rails 4.2, 5.0, 5.1, 5.2, and 6.0 are supported, Ruby 2.1+. Other Ruby runtimes (e.g. JRuby,
 Rubinius) probably work, but are not tested in Travis CI.
 
 Contributing


### PR DESCRIPTION
Travis testing was added in c5641e03058077ad69f4f91fe7f66b3f01075a86, and the tests are passing according to https://travis-ci.org/github/isaacseymour/activejob-retry.